### PR TITLE
ShellCheck on test cycle

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euox pipefail
 cd "$(dirname "$0")/.."
 trap "kill 0" EXIT
 
-# Start live server
+echo "Lint checks shell scripts" >&2
+shellcheck bin/*.sh
+
+echo "Starting test server" >&2
 ./bin/serve.sh 2>/dev/null >&2 &
 
-# Wait until server has started
+echo "Waiting for test server to become available..." >&2
 curl -sfSL -4 --retry 10 --retry-connrefused --retry-delay 2 "http://localhost:1313/" >/dev/null
 
-# Test the site
+echo "Run website tester" >&2
 echo '{
     "urls": ["http://localhost:1313/"],
     "ignoreRobotsTxt": true


### PR DESCRIPTION
Make sure that all the shell scripts are validated through ShellCheck.

Closes #53